### PR TITLE
Fixed redeem bug

### DIFF
--- a/contracts/Eth_broker.sol
+++ b/contracts/Eth_broker.sol
@@ -339,7 +339,7 @@ contract Eth_broker {
             "Curve burn failed"
         );
         // Getting expected ETH for DAI
-        uint256 ethMin = sellRewardDai(dai_.balanceOf(address(this)));
+        uint256 ethMin = sellRewardDai(_minDaiSellValue);
         // Approving the router as a spender
         require(
             dai_.approve(


### PR DESCRIPTION
Instead of using the balance of the broker in DAI (being the entire DAI value of the sold BZZ tokens) we use the passed in min DAI value. This means that the minimum amount of ETH (i.e the min slippage passed into uniV2) now has the slippage built into it, instead of being the full expected value. 

Note that tests were not updated, as Etherlime does not support having multiple solidity versions, meaning the Uni V2 contracts could not be imported for proper mocking. 

This change was tested against a mainnet fork using the deployed mainnet curve and DAI contracts. Let me know if you'd like me to walk you through the fix on a mainnet fork, happy to walk through it. 

---

Fix provided as is. 

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.